### PR TITLE
feat(nx-cloud): setup nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -18,7 +18,7 @@
     }
   },
   "defaultBase": "next",
-  "nxCloudId": "66ec589af76d115a9da91161",
+  "nxCloudId": "66ec5a33f76d115a9da9116a",
   "namedInputs": {
     "sharedGlobals": [
       "{workspaceRoot}/.github/workflows/ci.yml"


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace 
    
This commit set up Nx Cloud for your Nx workspace enabling distributed caching
and GitHub integration for fast CI and improved Developer Experience.

You can access your Nx Cloud workspace by going to 
https://staging.nx.app/orgs/66ec5a17f76d115a9da91168/workspaces/66ec5a33f76d115a9da9116a

**Note:** This commit attempts to maintain formatting of the nx.json, however you may need to correct formatting by running an nx format command and committing the changes.